### PR TITLE
Enable adjustable generator outputs on some xu generators

### DIFF
--- a/insane_patchers/targets.properties
+++ b/insane_patchers/targets.properties
@@ -4,3 +4,12 @@
 
 com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorFood=xu2_culinary.js
 cubex2.cs2.item.ItemCSFood=cs2_food.js
+
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorEnder=xu_ender.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorFurnace=xu_furnace.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorFurnaceOverClocked=xu_furnace_overclocked.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorFurnaceSurvival=xu_furnace_survival.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorMagma=xu_magma.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorNether=xu_netherstarjs
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorPink=xu_pink.js
+com.rwtema.extrautils.tileentity.generators.TileEntityGeneratorTNT=xu_explosion.js

--- a/insane_patchers/xu_ender.js
+++ b/insane_patchers/xu_ender.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_explosion.js
+++ b/insane_patchers/xu_explosion.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_furnace.js
+++ b/insane_patchers/xu_furnace.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_furnace_overclocked.js
+++ b/insane_patchers/xu_furnace_overclocked.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_furnace_survival.js
+++ b/insane_patchers/xu_furnace_survival.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_magma.js
+++ b/insane_patchers/xu_magma.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_netherstar.js
+++ b/insane_patchers/xu_netherstar.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();

--- a/insane_patchers/xu_pink.js
+++ b/insane_patchers/xu_pink.js
@@ -1,0 +1,17 @@
+// This defines the output rate, with unit of RF/t. Must be float-point number, i.e. has decimals.
+var gen_level = 10.0;
+
+var Opcodes = org.objectweb.asm.Opcodes;
+
+var methodGenLevelGetter = node.methods.stream().filter(function (m){
+    return m.name.equals("getGenLevel");
+}).findFirst().orElseThrow(function (){
+    return new java.lang.Error();
+});
+
+methodGenLevelGetter.instructions.clear();
+methodGenLevelGetter.visitLdcInsn(gen_level);
+methodGenLevelGetter.visitInsn(Opcodes.DRETURN);
+methodGenLevelGetter.visitEnd();
+
+node.visitEnd();


### PR DESCRIPTION
Including:
* Ender
* Furnace (incl. overclocked and survival)
* Magma
* Nether Star
* Pink
* TNT

Not including:
* Food (already balanced against AppleCore series)
* Potion (varies on potion level, hard to automate)
* RedFlux (need more consideration on how to adjust)
* Solar (Ignored.)